### PR TITLE
parsing french tooltips for duration fix

### DIFF
--- a/OutfitterStrings_fr.lua
+++ b/OutfitterStrings_fr.lua
@@ -354,9 +354,9 @@ if GetLocale() == "frFR" then
 	Outfitter.cScriptLabel = "Scripte:"
 
 	Outfitter.cNone = "None"
-	Outfitter.cUseTooltipLineFormat = "^Utiliser:.*"
-	Outfitter.cUseDurationTooltipLineFormat = "^Utiliser:.*pendant (%d+) seconds"
-	Outfitter.cUseDurationTooltipLineFormat2 = "^Utiliser:.*Dure (%d+) sec"
+	Outfitter.cUseTooltipLineFormat = "^Utiliser : .*"
+	Outfitter.cUseDurationTooltipLineFormat = "^Utiliser : .*pendant (%d+) sec"
+	Outfitter.cUseDurationTooltipLineFormat2 = "^Utiliser : .*Dure (%d+) sec"
 	
 	Outfitter.cAutoChangesDisabled = "Automated changes are now disabled"
 	Outfitter.cAutoChangesEnabled = "Automated changes are now enabled"


### PR DESCRIPTION
I haven't tested cUseTooltipLineFormat and cUseDurationTooltipLineFormat2, but there should be spaces around the colon (and it's the case of several items I have which match cUseDurationTooltipLineFormat).
Also for cUseDurationTooltipLineFormat, french for "seconds" is "secondes", but I have only seen the short "sec." on my items.