### PR TITLE
Fix "no events found for Hawk" error

### DIFF
--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -954,6 +954,7 @@ Outfitter.cSpecialIDEvents =
 	GhostWolf = {Equip = "GHOST_WOLF", Unequip = "NOT_GHOST_WOLF"},
 
 	Feigning = {Equip = "FEIGN_DEATH", Unequip = "NOT_FEIGN_DEATH"},
+	Hawk = {Equip = "HAWK", Unequip = "NOT_HAWK"},
 	
 	Evocate = {Equip = "EVOCATE", Unequip = "NOT_EVOCATE"},
 	


### PR DESCRIPTION
Hawk is mapped in [`cSpellIDToSpecialID`](https://github.com/cdmichaelb/Outfitter/blob/4039d5d392421aae46b3d893860f4fee72f08722/Outfitter.lua#L1036-L1054) which means its events are enabled by default, but not in `cSpecialIDEvents` so its events are currently not handled.

Closes #48 and #32.   Thanks @GovtGeek for the suggestion.