### PR TITLE
Fix #87 - Add backdrop mixin to GameTooltip

### DIFF
--- a/Libraries/LibDropdown-1.0.lua
+++ b/Libraries/LibDropdown-1.0.lua
@@ -93,8 +93,11 @@ end
 
 -- Make the frame match the tooltip
 local function InitializeFrame(frame)
-	-- local backdrop = GameTooltip:GetBackdrop()
-	local backdrop = GameTooltip.NineSlice:GetBackdrop()
+        if not GameTooltip.GetBackdrop then
+            Mixin(GameTooltip, BackdropTemplateMixin)
+        end
+
+	local backdrop = GameTooltip:GetBackdrop()
 
 	frame:SetBackdrop(backdrop)
 

--- a/Libraries/LibDropdown-1.0.lua
+++ b/Libraries/LibDropdown-1.0.lua
@@ -93,18 +93,25 @@ end
 
 -- Make the frame match the tooltip
 local function InitializeFrame(frame)
-        if not GameTooltip.GetBackdrop then
-            Mixin(GameTooltip, BackdropTemplateMixin)
-        end
-
-	local backdrop = GameTooltip.NineSlice:GetBackdrop()
-
-	frame:SetBackdrop(backdrop)
-
-	if backdrop then
-		frame:SetBackdropColor(GameTooltip.NineSlice:GetBackdropColor())
-		frame:SetBackdropBorderColor(GameTooltip.NineSlice:GetBackdropBorderColor())
+	if not GameTooltip.GetBackdrop then
+		Mixin(GameTooltip, BackdropTemplateMixin)
 	end
+
+	if GameTooltip.NineSlice.GetBackdrop then
+		local backdrop = GameTooltip.NineSlice:GetBackdrop()
+
+		frame:SetBackdrop(backdrop)
+
+		if backdrop then
+			frame:SetBackdropColor(GameTooltip.NineSlice:GetBackdropColor())
+			frame:SetBackdropBorderColor(GameTooltip.NineSlice:GetBackdropBorderColor())
+		end
+	else
+		-- If we don't have a backdrop to mimic from the tooltip, use a sane default
+		-- BACKDROP_DARK_DIALOG_32_32 is a blizzard backdrop global
+		frame:SetBackdrop(BACKDROP_DARK_DIALOG_32_32)
+	end
+
 	frame:SetScale(GameTooltip:GetScale())
 end
 

--- a/Libraries/LibDropdown-1.0.lua
+++ b/Libraries/LibDropdown-1.0.lua
@@ -97,13 +97,13 @@ local function InitializeFrame(frame)
             Mixin(GameTooltip, BackdropTemplateMixin)
         end
 
-	local backdrop = GameTooltip:GetBackdrop()
+	local backdrop = GameTooltip.NineSlice:GetBackdrop()
 
 	frame:SetBackdrop(backdrop)
 
 	if backdrop then
-		frame:SetBackdropColor(GameTooltip:GetBackdropColor())
-		frame:SetBackdropBorderColor(GameTooltip:GetBackdropBorderColor())
+		frame:SetBackdropColor(GameTooltip.NineSlice:GetBackdropColor())
+		frame:SetBackdropBorderColor(GameTooltip.NineSlice:GetBackdropBorderColor())
 	end
 	frame:SetScale(GameTooltip:GetScale())
 end

--- a/OutfitterBar.lua
+++ b/OutfitterBar.lua
@@ -1,3 +1,13 @@
+-- Global Backdrops
+BACKDROP_OUTFITTER_DIALOG_32_32 = {
+	bgFile = "Interface\\Addons\\Outfitter\\Textures\\DialogBox-Background",
+	edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
+	tile = true,
+	tileSize = 32,
+	edgeSize = 32,
+	insets = { left = 11, right = 12, top = 12, bottom = 11 },
+}
+
 ----------------------------------------
 Outfitter.OutfitBar = {}
 ----------------------------------------

--- a/OutfitterBar.xml
+++ b/OutfitterBar.xml
@@ -1,18 +1,10 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\FrameXML\UI.xsd">
 	
-	<Frame name="OutfitterDialogFrameTemplate" setAllPoints="true" virtual="true">
-		<Backdrop bgFile="Interface\Addons\Outfitter\Textures\DialogBox-Background" edgeFile="Interface\DialogFrame\UI-DialogBox-Border" tile="true">
-			<BackgroundInsets>
-				<AbsInset left="11" right="12" top="12" bottom="11"/>
-			</BackgroundInsets>
-			<TileSize>
-				<AbsValue val="32"/>
-			</TileSize>
-			<EdgeSize>
-				<AbsValue val="32"/>
-			</EdgeSize>
-		</Backdrop>
+	<Frame name="OutfitterDialogFrameTemplate" setAllPoints="true" virtual="true" inherits="BackdropTemplate" inherit="prepend">
+		<KeyValues>
+			<KeyValue key="backdropInfo" value="BACKDROP_OUTFITTER_DIALOG_32_32" type="global"/>
+		</KeyValues>
 		<Scripts>
 			<OnShow>
 				self:SetFrameLevel(self:GetParent():GetFrameLevel())


### PR DESCRIPTION
## Included in this PR

- Fixes #87 
  - Apply the proper mixin to gametooltip when skinning the dropdown frame 
    - The latest WoW API has removed backdrops on frames by default, and now requires that you extend the proper backdrop template, or use a mixin to reapply the backdrop interface.
  - Reference the `NineSlice` subframe for backdrop settings on `GameTooltip`
  - Remove deprecated XML frame `<Backdrop>` templates and convert them to the latest API
  - Default the dropdown to a global blizzard backdrop when we can't find one on the tooltip
    - There are some odd cases where it seems that `GetBackdrop` isn't actually defined on the `NineSlice`. If we can determine why we might be able to improve this to avoid any chances of ignoring reskinned tooltips (for instance from AddonSkins).

### Results:

![image](https://user-images.githubusercontent.com/29235654/150288119-0f33e1d4-c010-423e-913c-786911a8390a.png)