### PR TITLE
fix: nil pointer exception

### DIFF
--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -1894,7 +1894,7 @@ function Outfitter:DeleteSelectedOutfit()
 end
 
 function Outfitter:TalentsChanged()
-	self.CanDualWield2H = self.PlayerClass == "WARRIOR" and GetSpecialization() == 2
+	self.CanDualWield2H = self.PlayerClass == "WARRIOR" and select(5, GetTalentInfo(2, 24)) > 0
 end
 
 function Outfitter:SetScript(pOutfit, pScript)


### PR DESCRIPTION
Check for Titan's Grip Warrior's was coded in terms of its operation on retail. Checking the WOTLK talent manually solves this issue.

See: https://github.com/cdmichaelb/Outfitter/issues/110