### PR TITLE
P4 - Unique-Equipped gems fix

### DIFF
--- a/OutfitterEquipment.lua
+++ b/OutfitterEquipment.lua
@@ -83,6 +83,7 @@ function Outfitter._EquipmentChanges:addChangesToEquipOutfit(outfit, inventoryCa
 		return nil
 	end
 
+	-- print("adjustUniqueEquipSwaps")
 	self:adjustUniqueEquipSwaps()
 	self:optimize()
 end
@@ -464,7 +465,7 @@ function Outfitter._EquipmentChanges:optimize()
 end
 
 function Outfitter._EquipmentChanges:execute(emptyBagSlots, expectedInventoryCache)
-	--print(expectedInventoryCache)
+	-- print(expectedInventoryCache)
 	-- Disable sound effects during the swap
 	local savedEnabledSFXValue
 	if not Outfitter.Settings.EnableEquipSounds then
@@ -564,6 +565,7 @@ function Outfitter._EquipmentChange:construct(inventorySlot, itemName)
 end
 
 function Outfitter._EquipmentChange:subtractInventoryUniqueEquipTotals()
+	-- print('subtractInventoryUniqueEquipTotals')
 	-- Get the item
 	local itemInfo = Outfitter:GetSlotIDItemInfo(self.SlotID)
 
@@ -573,16 +575,18 @@ function Outfitter._EquipmentChange:subtractInventoryUniqueEquipTotals()
 	end
 
 	-- Get the unique-equip types
-	local uniqueEquipTypes = itemInfo:GetUniqueEquipTypes()
-
-	-- Done if there are no unique-equip types
-	if not uniqueEquipTypes then
-		return
-	end
+	local uniqueEquipTypes, gemUniqueEquipTypes = itemInfo:GetUniqueEquipTypes()
 
 	-- Subtract the counts
-	for uniqueEquipType in pairs(uniqueEquipTypes) do
-		self.uniqueEquipTotals[uniqueEquipType] = (self.uniqueEquipTotals[uniqueEquipType] or 0) - 1
+	if uniqueEquipTypes then
+		for uniqueEquipType in pairs(uniqueEquipTypes) do
+			self.uniqueEquipTotals[uniqueEquipType] = (self.uniqueEquipTotals[uniqueEquipType] or 0) - 1
+		end
+	end
+	if gemUniqueEquipTypes then
+		for uniqueEquipType in pairs(gemUniqueEquipTypes) do
+			self.uniqueEquipTotals[uniqueEquipType] = (self.uniqueEquipTotals[uniqueEquipType] or 0) - 1
+		end
 	end
 end
 
@@ -601,21 +605,25 @@ function Outfitter._EquipmentChange:addLocationUniqueEquipTotals(location)
 	end
 
 	-- Get the unique-equip types
-	local uniqueEquipTypes = itemInfo:GetUniqueEquipTypes()
-
-	-- Done if there are no unique-equip types
-	if not uniqueEquipTypes then
-		return
-	end
+	local uniqueEquipTypes, gemUniqueEquipTypes = itemInfo:GetUniqueEquipTypes()
 
 	-- Add the counts
-	for uniqueEquipType in pairs(uniqueEquipTypes) do
-		self.uniqueEquipTotals[uniqueEquipType] = (self.uniqueEquipTotals[uniqueEquipType] or 0) + 1
+	if uniqueEquipTypes then
+		for uniqueEquipType in pairs(uniqueEquipTypes) do
+			self.uniqueEquipTotals[uniqueEquipType] = (self.uniqueEquipTotals[uniqueEquipType] or 0) + 1
+		end
+	end
+	if gemUniqueEquipTypes then
+		for uniqueEquipType in pairs(gemUniqueEquipTypes) do
+			self.uniqueEquipTotals[uniqueEquipType] = (self.uniqueEquipTotals[uniqueEquipType] or 0) + 1
+		end
 	end
 end
 
 function Outfitter._EquipmentChange:calcUniqueEquipOrderingRank(uniqueEquipCountOffsets)
 	local hasNegative, hasPositive
+
+	-- print('uniqueEquipTotals len' .. #self.uniqueEquipTotals)
 
 	-- Check each total
 	for uniqueID, uniqueCount in pairs(self.uniqueEquipTotals) do

--- a/OutfitterEquipment.lua
+++ b/OutfitterEquipment.lua
@@ -573,18 +573,11 @@ function Outfitter._EquipmentChange:subtractInventoryUniqueEquipTotals()
 	end
 
 	-- Get the unique-equip types
-	local uniqueEquipTypes, gemUniqueEquipTypes = itemInfo:GetUniqueEquipTypes()
+	local uniqueEquipTypes = itemInfo:GetUniqueEquipTypes()
 
 	-- Subtract the counts
-	if uniqueEquipTypes then
-		for uniqueEquipType in pairs(uniqueEquipTypes) do
-			self.uniqueEquipTotals[uniqueEquipType] = (self.uniqueEquipTotals[uniqueEquipType] or 0) - 1
-		end
-	end
-	if gemUniqueEquipTypes then
-		for uniqueEquipType in pairs(gemUniqueEquipTypes) do
-			self.uniqueEquipTotals[uniqueEquipType] = (self.uniqueEquipTotals[uniqueEquipType] or 0) - 1
-		end
+	for uniqueEquipType in pairs(uniqueEquipTypes) do
+		self.uniqueEquipTotals[uniqueEquipType] = (self.uniqueEquipTotals[uniqueEquipType] or 0) - 1
 	end
 end
 
@@ -603,18 +596,11 @@ function Outfitter._EquipmentChange:addLocationUniqueEquipTotals(location)
 	end
 
 	-- Get the unique-equip types
-	local uniqueEquipTypes, gemUniqueEquipTypes = itemInfo:GetUniqueEquipTypes()
+	local uniqueEquipTypes = itemInfo:GetUniqueEquipTypes()
 
 	-- Add the counts
-	if uniqueEquipTypes then
-		for uniqueEquipType in pairs(uniqueEquipTypes) do
-			self.uniqueEquipTotals[uniqueEquipType] = (self.uniqueEquipTotals[uniqueEquipType] or 0) + 1
-		end
-	end
-	if gemUniqueEquipTypes then
-		for uniqueEquipType in pairs(gemUniqueEquipTypes) do
-			self.uniqueEquipTotals[uniqueEquipType] = (self.uniqueEquipTotals[uniqueEquipType] or 0) + 1
-		end
+	for uniqueEquipType in pairs(uniqueEquipTypes) do
+		self.uniqueEquipTotals[uniqueEquipType] = (self.uniqueEquipTotals[uniqueEquipType] or 0) + 1
 	end
 end
 

--- a/OutfitterEquipment.lua
+++ b/OutfitterEquipment.lua
@@ -83,7 +83,6 @@ function Outfitter._EquipmentChanges:addChangesToEquipOutfit(outfit, inventoryCa
 		return nil
 	end
 
-	-- print("adjustUniqueEquipSwaps")
 	self:adjustUniqueEquipSwaps()
 	self:optimize()
 end
@@ -465,7 +464,7 @@ function Outfitter._EquipmentChanges:optimize()
 end
 
 function Outfitter._EquipmentChanges:execute(emptyBagSlots, expectedInventoryCache)
-	-- print(expectedInventoryCache)
+	--print(expectedInventoryCache)
 	-- Disable sound effects during the swap
 	local savedEnabledSFXValue
 	if not Outfitter.Settings.EnableEquipSounds then
@@ -565,7 +564,6 @@ function Outfitter._EquipmentChange:construct(inventorySlot, itemName)
 end
 
 function Outfitter._EquipmentChange:subtractInventoryUniqueEquipTotals()
-	-- print('subtractInventoryUniqueEquipTotals')
 	-- Get the item
 	local itemInfo = Outfitter:GetSlotIDItemInfo(self.SlotID)
 
@@ -622,8 +620,6 @@ end
 
 function Outfitter._EquipmentChange:calcUniqueEquipOrderingRank(uniqueEquipCountOffsets)
 	local hasNegative, hasPositive
-
-	-- print('uniqueEquipTotals len' .. #self.uniqueEquipTotals)
 
 	-- Check each total
 	for uniqueID, uniqueCount in pairs(self.uniqueEquipTotals) do

--- a/OutfitterInventory.lua
+++ b/OutfitterInventory.lua
@@ -394,8 +394,6 @@ function Outfitter._ItemInfo:ParseTooltip()
 		return
 	end
 
-	-- print(self.Link)
-		
 	-- Return if something went wrong
 	if not tooltip:IsShown() then
 		return

--- a/OutfitterInventory.lua
+++ b/OutfitterInventory.lua
@@ -77,7 +77,19 @@ function Outfitter:GetBagItemInfo(bagIndex, slotIndex)
 	local location = ItemLocation:CreateFromBagAndSlot(bagIndex, slotIndex)
 
 	itemInfo.Texture = GetContainerItemInfo(bagIndex, slotIndex)
-	-- itemInfo.Gem1, itemInfo.Gem2, itemInfo.Gem3, itemInfo.Gem4 = GetContainerItemGems(bagIndex, slotIndex)
+	itemInfo.Gem1, itemInfo.Gem2, itemInfo.Gem3, itemInfo.Gem4 = GetContainerItemGems(bagIndex, slotIndex)
+	if itemInfo.Gem1 ~= nil then
+		itemInfo.Gem1Link = select(2, GetItemInfo(itemInfo.Gem1))
+	end
+	if itemInfo.Gem2 ~= nil then
+		itemInfo.Gem2Link = select(2, GetItemInfo(itemInfo.Gem2))
+	end
+	if itemInfo.Gem3 ~= nil then
+		itemInfo.Gem3Link = select(2, GetItemInfo(itemInfo.Gem3))
+	end
+	if itemInfo.Gem4 ~= nil then
+		itemInfo.Gem4Link = select(2, GetItemInfo(itemInfo.Gem4))
+	end
 	itemInfo.AzeriteCodes = self:GetAzeriteCodesForLocation(location)
 	itemInfo.Location = {BagIndex = bagIndex, BagSlotIndex = slotIndex}
 	
@@ -381,6 +393,8 @@ function Outfitter._ItemInfo:ParseTooltip()
 		assert(false, "can't find item for tooltip")
 		return
 	end
+
+	-- print(self.Link)
 		
 	-- Return if something went wrong
 	if not tooltip:IsShown() then
@@ -392,8 +406,39 @@ function Outfitter._ItemInfo:ParseTooltip()
 		self:ParseTooltipLine(line.leftText, line.leftColor)
 	end
 
+	self:ParseGemLinkForUniqueEquips(self.Gem1Link)
+	self:ParseGemLinkForUniqueEquips(self.Gem2Link)
+	self:ParseGemLinkForUniqueEquips(self.Gem3Link)
+	self:ParseGemLinkForUniqueEquips(self.Gem4Link)
+
 	-- Done
 	self.didParseTooltip = true
+end
+
+function Outfitter._ItemInfo:ParseGemLinkForUniqueEquips(link)
+	-- Item didnt have that Gem1/Gem2/etc, or already found
+	if self.GemUniqueType ~= nil or link == nil then
+		return
+	end
+
+	local tooltip = Outfitter.TooltipLib:SharedTooltip()
+	tooltip:ClearLines()
+	tooltip:SetHyperlink(link)
+
+	-- Return if something went wrong
+	if not tooltip:IsShown() then
+		return
+	end
+
+	for line in Outfitter.TooltipLib:TooltipLines(tooltip) do
+		-- Check for Unique-Equipped
+		local type, count = line.leftText:match(Outfitter.cUniqueEquippedSearchPattern)
+		if type then
+			self.GemUniqueType = type
+			self.GemUniqueCount = tonumber(count)
+			return
+		end
+	end
 end
 
 function Outfitter._ItemInfo:ParseTooltipLine(text, color)
@@ -445,13 +490,16 @@ function Outfitter._ItemInfo:GetUniqueEquipTypes()
 		self:ParseTooltip()
 	end
 	
-	-- Return nothing if there is nothing
-	if not self.UniqueType then
-		return
+	local itemTable = {}
+	if  self.UniqueType then
+		itemTable = {[self.UniqueType] = self.UniqueCount}
 	end
-	
-	-- Return the values
-	return {[self.UniqueType] = self.UniqueCount}
+	local gemTable = {}
+	if self.GemUniqueType then
+		gemTable = {[self.GemUniqueType] = self.GemUniqueCount}
+	end
+
+	return itemTable, gemTable
 end
 
 ----------------------------------------
@@ -491,7 +539,19 @@ function Outfitter:GetSlotIDItemInfo(slotID)
 
 	itemInfo.Quality = GetInventoryItemQuality("player", slotID)
 	itemInfo.Texture = GetInventoryItemTexture("player", slotID)
-	-- itemInfo.Gem1, itemInfo.Gem2, itemInfo.Gem3, itemInfo.Gem4 = GetInventoryItemGems(slotID)
+	itemInfo.Gem1, itemInfo.Gem2, itemInfo.Gem3, itemInfo.Gem4 = GetInventoryItemGems(slotID)
+	if itemInfo.Gem1 ~= nil then
+		itemInfo.Gem1Link = select(2, GetItemInfo(itemInfo.Gem1))
+	end
+	if itemInfo.Gem2 ~= nil then
+		itemInfo.Gem2Link = select(2, GetItemInfo(itemInfo.Gem2))
+	end
+	if itemInfo.Gem3 ~= nil then
+		itemInfo.Gem3Link = select(2, GetItemInfo(itemInfo.Gem3))
+	end
+	if itemInfo.Gem4 ~= nil then
+		itemInfo.Gem4Link = select(2, GetItemInfo(itemInfo.Gem4))
+	end
 	itemInfo.AzeriteCodes = self:GetAzeriteCodesForLocation(location)
 	itemInfo.Location = {SlotID = slotID}
 

--- a/OutfitterInventory.lua
+++ b/OutfitterInventory.lua
@@ -404,19 +404,19 @@ function Outfitter._ItemInfo:ParseTooltip()
 		self:ParseTooltipLine(line.leftText, line.leftColor)
 	end
 
-	self:ParseGemLinkForUniqueEquips(self.Gem1Link)
-	self:ParseGemLinkForUniqueEquips(self.Gem2Link)
-	self:ParseGemLinkForUniqueEquips(self.Gem3Link)
-	self:ParseGemLinkForUniqueEquips(self.Gem4Link)
+	self.Gem1UniqueType, self.Gem1UniqueCount = self:ParseGemLinkForUniqueEquips(self.Gem1Link)
+	self.Gem2UniqueType, self.Gem2UniqueCount = self:ParseGemLinkForUniqueEquips(self.Gem2Link)
+	self.Gem3UniqueType, self.Gem3UniqueCount = self:ParseGemLinkForUniqueEquips(self.Gem3Link)
+	self.Gem4UniqueType, self.Gem4UniqueCount = self:ParseGemLinkForUniqueEquips(self.Gem4Link)
 
 	-- Done
 	self.didParseTooltip = true
 end
 
 function Outfitter._ItemInfo:ParseGemLinkForUniqueEquips(link)
-	-- Item didnt have that Gem1/Gem2/etc, or already found
-	if self.GemUniqueType ~= nil or link == nil then
-		return
+	-- Item didnt have that Gem1/Gem2/etc
+	if link == nil then
+		return nil, nil
 	end
 
 	local tooltip = Outfitter.TooltipLib:SharedTooltip()
@@ -425,18 +425,18 @@ function Outfitter._ItemInfo:ParseGemLinkForUniqueEquips(link)
 
 	-- Return if something went wrong
 	if not tooltip:IsShown() then
-		return
+		return nil, nil
 	end
 
 	for line in Outfitter.TooltipLib:TooltipLines(tooltip) do
 		-- Check for Unique-Equipped
 		local type, count = line.leftText:match(Outfitter.cUniqueEquippedSearchPattern)
 		if type then
-			self.GemUniqueType = type
-			self.GemUniqueCount = tonumber(count)
-			return
+			return type, tonumber(count)
 		end
 	end
+
+	return nil, nil
 end
 
 function Outfitter._ItemInfo:ParseTooltipLine(text, color)
@@ -488,16 +488,24 @@ function Outfitter._ItemInfo:GetUniqueEquipTypes()
 		self:ParseTooltip()
 	end
 	
-	local itemTable = {}
-	if  self.UniqueType then
-		itemTable = {[self.UniqueType] = self.UniqueCount}
+	local uniqueTypesTable = {}
+	if self.UniqueType then
+		uniqueTypesTable[self.UniqueType] = self.UniqueCount
 	end
-	local gemTable = {}
-	if self.GemUniqueType then
-		gemTable = {[self.GemUniqueType] = self.GemUniqueCount}
+	if self.Gem1UniqueType then
+		uniqueTypesTable[self.Gem1UniqueType] = self.Gem1UniqueCount
+	end
+	if self.Gem2UniqueType then
+		uniqueTypesTable[self.Gem2UniqueType] = self.Gem2UniqueCount
+	end
+	if self.Gem3UniqueType then
+		uniqueTypesTable[self.Gem3UniqueType] = self.Gem3UniqueCount
+	end
+	if self.Gem4UniqueType then
+		uniqueTypesTable[self.Gem4UniqueType] = self.Gem4UniqueCount
 	end
 
-	return itemTable, gemTable
+	return uniqueTypesTable
 end
 
 ----------------------------------------

--- a/OutfitterInventory.lua
+++ b/OutfitterInventory.lua
@@ -545,19 +545,23 @@ function Outfitter:GetSlotIDItemInfo(slotID)
 
 	itemInfo.Quality = GetInventoryItemQuality("player", slotID)
 	itemInfo.Texture = GetInventoryItemTexture("player", slotID)
-	itemInfo.Gem1, itemInfo.Gem2, itemInfo.Gem3, itemInfo.Gem4 = GetInventoryItemGems(slotID)
-	if itemInfo.Gem1 ~= nil then
-		itemInfo.Gem1Link = select(2, GetItemInfo(itemInfo.Gem1))
+
+	if slotID then
+		itemInfo.Gem1, itemInfo.Gem2, itemInfo.Gem3, itemInfo.Gem4 = GetInventoryItemGems(slotID)
+		if itemInfo.Gem1 ~= nil then
+			itemInfo.Gem1Link = select(2, GetItemInfo(itemInfo.Gem1))
+		end
+		if itemInfo.Gem2 ~= nil then
+			itemInfo.Gem2Link = select(2, GetItemInfo(itemInfo.Gem2))
+		end
+		if itemInfo.Gem3 ~= nil then
+			itemInfo.Gem3Link = select(2, GetItemInfo(itemInfo.Gem3))
+		end
+		if itemInfo.Gem4 ~= nil then
+			itemInfo.Gem4Link = select(2, GetItemInfo(itemInfo.Gem4))
+		end
 	end
-	if itemInfo.Gem2 ~= nil then
-		itemInfo.Gem2Link = select(2, GetItemInfo(itemInfo.Gem2))
-	end
-	if itemInfo.Gem3 ~= nil then
-		itemInfo.Gem3Link = select(2, GetItemInfo(itemInfo.Gem3))
-	end
-	if itemInfo.Gem4 ~= nil then
-		itemInfo.Gem4Link = select(2, GetItemInfo(itemInfo.Gem4))
-	end
+
 	itemInfo.AzeriteCodes = self:GetAzeriteCodesForLocation(location)
 	itemInfo.Location = {SlotID = slotID}
 


### PR DESCRIPTION
Adding support for Unique-Equipped gems. During set swaps, items with Dragon's Eye gems were conflicting with each other resulting in needing to set swap twice.

Implementation uses the existing Unique-Equipped code, only copied the code where necessary to get gems working.

See: #104