### PR TITLE
Fish tracking fix and restore tracking for "spell" types

### DIFF
--- a/Outfitter.lua
+++ b/Outfitter.lua
@@ -7315,13 +7315,22 @@ function Outfitter:PlayerIsOnQuestID(pQuestID)
 	return false
 end
 
-function Outfitter:GetTrackingEnabled(pTexture)
-	local vNumTypes = GetNumTrackingTypes()
-
+function Outfitter:GetCurrentSpellTrackingEnabled()
+	local vNumTypes = C_Minimap.GetNumTrackingTypes();
 	for vIndex = 1, vNumTypes do
-		local vName, vTexture, vActive = GetTrackingInfo(vIndex)
+		local vName, vTexture, vActive, vType = C_Minimap.GetTrackingInfo(vIndex);
+		if vActive and vType == "spell" then
+			return vTexture;
+		end
+	end
+end
+
+function Outfitter:GetTrackingEnabled(pTexture)
+	local vNumTypes = C_Minimap.GetNumTrackingTypes();	
+	for vIndex = 1, vNumTypes do
+		local vName, vTexture, vActive = C_Minimap.GetTrackingInfo(vIndex);
 		if vTexture == pTexture then
-			return vActive, vIndex
+			return vActive, vIndex;
 		end
 	end
 end
@@ -7329,7 +7338,7 @@ end
 function Outfitter:SetTrackingEnabled(pTexture, pEnabled)
 	local vActive, vIndex = self:GetTrackingEnabled(pTexture)
 	if vActive ~= pEnabled then
-		SetTracking(vIndex, pEnabled == true or pEnabled == 1)
+		C_Minimap.SetTracking(vIndex, pEnabled == true or pEnabled == 1)
 	end
 end
 

--- a/OutfitterScripting.lua
+++ b/OutfitterScripting.lua
@@ -821,9 +821,11 @@ if event == "OUTFIT_EQUIPPED" then
     end
     
     if setting.EnableFishTracking then
-        setting.savedTracking = Outfitter:GetCurrentSpellTrackingEnabled()
-        Outfitter:SetTrackingEnabled(133888, 1)
-        setting.didSetTracking = true
+		if Outfitter:GetTrackingEnabled(133888) then
+			setting.savedTracking = Outfitter:GetCurrentSpellTrackingEnabled()
+			Outfitter:SetTrackingEnabled(133888, 1)
+			setting.didSetTracking = true
+		end
     end
     
    if setting.DisableClicktoMove then

--- a/OutfitterScripting.lua
+++ b/OutfitterScripting.lua
@@ -821,7 +821,8 @@ if event == "OUTFIT_EQUIPPED" then
     end
     
     if setting.EnableFishTracking then
-		if Outfitter:GetTrackingEnabled(133888) then
+		local _, vIndex = Outfitter:GetTrackingEnabled(133888)
+		if vIndex then
 			setting.savedTracking = Outfitter:GetCurrentSpellTrackingEnabled()
 			Outfitter:SetTrackingEnabled(133888, 1)
 			setting.didSetTracking = true

--- a/OutfitterScripting.lua
+++ b/OutfitterScripting.lua
@@ -821,7 +821,7 @@ if event == "OUTFIT_EQUIPPED" then
     end
     
     if setting.EnableFishTracking then
-        setting.savedTracking = Outfitter:GetTrackingEnabled(133888)
+        setting.savedTracking = Outfitter:GetCurrentSpellTrackingEnabled()
         Outfitter:SetTrackingEnabled(133888, 1)
         setting.didSetTracking = true
     end
@@ -848,7 +848,11 @@ elseif event == "OUTFIT_UNEQUIPPED" then
    end
  
    if setting.EnableFishTracking and setting.didSetTracking then
-       Outfitter:SetTrackingEnabled(133888, setting.savedTracking)
+       if setting.savedTracking then
+	      Outfitter:SetTrackingEnabled(setting.savedTracking, true)
+	   else
+	      Outfitter:SetTrackingEnabled(133888, false)  -- no spell tracking was enabled
+	   end
        setting.didSetTracking = nil
        setting.savedTracking = nil
    end


### PR DESCRIPTION
Changes to fix a bug where C_Minimap namespace had not been added to GetTrackingEnabled and SetTrackingEnabled functions.
Also added new function GetCurrentSpellTrackingEnabled and updated the fishing outfit script to make use of it. With changes outfitter can now restore whichever tracking the user had in place previously.