### PR TITLE
Update OutfitterScripting.lua to add nameplate option to fishing

### DIFF
--- a/OutfitterScripting.lua
+++ b/OutfitterScripting.lua
@@ -808,6 +808,7 @@ end
 [[
 -- $SETTING EnableFishTracking={type="boolean", label="Select Track Fish while equipped", default=true}
 -- $SETTING EnableAutoLoot={type="boolean", label="Enable auto loot while equipped"}
+-- $SETTING DisableEnemyNamePlates={type="boolean", label="Disable enemy name bars while equiped", default=false}
 -- $SETTING DisableClicktoMove={type="boolean", label="Disable Click-to-Move while equipped", default=true} 
 -- $SETTING ChangeActionBar={type="boolean", label="Switch action bars while equipped", default=false}
 -- $SETTING ActionBarNumber={type="number", label="Action bar (1 - 6)", default=1}
@@ -838,6 +839,12 @@ if event == "OUTFIT_EQUIPPED" then
        setting.didChangeActionBar = true
    end
 
+	if setting.DisableEnemyNamePlates then
+        setting.savedShowEnemies = GetCVar("nameplateShowEnemies")
+        SetCVar("nameplateShowEnemies", 0)
+        setting.didChangeShowEnemies = true
+    end
+
 -- Turn auto looting back off if the outfit is being unequipped and we turned it on
 
 elseif event == "OUTFIT_UNEQUIPPED" then
@@ -864,6 +871,12 @@ elseif event == "OUTFIT_UNEQUIPPED" then
       setting.didChangeActionBar = nil
       setting.savedActionBar = nil
   end
+
+	if setting.didChangeShowEnemies then
+        SetCVar("nameplateShowEnemies", setting.savedShowEnemies)
+        setting.didChangeShowEnemies = nil
+        setting.savedShowEnemies = nil
+    end
 end
 
 if equip == equipped then


### PR DESCRIPTION
Because while fishing enemy nameplates can sometimes be in the way of the bobber, added the option to have the nameplates turned off while the fishing outfit is equipped. Saves and restores the previous enemy nameplate state once fishing outfit is removed.